### PR TITLE
Engine: Implement Y-Axis Clustering

### DIFF
--- a/engine/codex_engine/heuristics.py
+++ b/engine/codex_engine/heuristics.py
@@ -1,9 +1,9 @@
 from collections import Counter
-from typing import Iterable, Dict, Any, List
+from typing import Iterable, Any
 
-def cluster_spans_by_y(spans: List[Dict[str, Any]], tolerance: float = 2.0) -> List[List[Dict[str, Any]]]:
+def cluster_spans_by_y(spans: list[dict[str, Any]], tolerance: float = 2.0) -> list[list[dict[str, Any]]]:
     """
-    Groups spans into horizontal lines based on their Y-coordinate.
+    Groups spans into horizontal lines based on their Y-coordinate using a sliding reference.
 
     Args:
         spans: A list of span dictionaries, each containing a "bbox" key [x0, y0, x1, y1].
@@ -11,20 +11,34 @@ def cluster_spans_by_y(spans: List[Dict[str, Any]], tolerance: float = 2.0) -> L
 
     Returns:
         A list of clusters, where each cluster is a list of spans sorted by X-coordinate.
+
+    Raises:
+        ValueError: If tolerance is negative.
+        KeyError: If a span is missing the "bbox" key.
+        IndexError: If a bbox has fewer than 2 elements.
     """
+    if tolerance < 0:
+        raise ValueError("Tolerance must be non-negative.")
+
     if not spans:
         return []
 
     # Sort spans by y0 (top coordinate)
-    sorted_spans = sorted(spans, key=lambda s: s["bbox"][1])
+    # This also serves as initial validation: each span must have bbox[1]
+    try:
+        sorted_spans = sorted(spans, key=lambda s: s["bbox"][1])
+    except (KeyError, IndexError) as e:
+        raise type(e)(f"Malformed span: {e}") from e
 
     clusters = []
     current_cluster = [sorted_spans[0]]
-    reference_y = sorted_spans[0]["bbox"][1]
 
     for i in range(1, len(sorted_spans)):
         span = sorted_spans[i]
-        if abs(span["bbox"][1] - reference_y) <= tolerance:
+        # Sliding reference: compare to the last span added to the cluster
+        last_span = current_cluster[-1]
+
+        if abs(span["bbox"][1] - last_span["bbox"][1]) <= tolerance:
             current_cluster.append(span)
         else:
             # Sort the completed cluster by x0
@@ -32,7 +46,6 @@ def cluster_spans_by_y(spans: List[Dict[str, Any]], tolerance: float = 2.0) -> L
             clusters.append(current_cluster)
             # Start new cluster
             current_cluster = [span]
-            reference_y = span["bbox"][1]
 
     # Sort and add the last cluster
     current_cluster.sort(key=lambda s: s["bbox"][0])
@@ -40,7 +53,7 @@ def cluster_spans_by_y(spans: List[Dict[str, Any]], tolerance: float = 2.0) -> L
 
     return clusters
 
-def calculate_base_size(spans: Iterable[Dict[str, Any]]) -> float:
+def calculate_base_size(spans: Iterable[dict[str, Any]]) -> float:
     """
     Calculates the BaseSize (most frequent font size) from a stream of PDF spans.
 

--- a/engine/codex_engine/heuristics.py
+++ b/engine/codex_engine/heuristics.py
@@ -1,5 +1,44 @@
 from collections import Counter
-from typing import Iterable, Dict, Any
+from typing import Iterable, Dict, Any, List
+
+def cluster_spans_by_y(spans: List[Dict[str, Any]], tolerance: float = 2.0) -> List[List[Dict[str, Any]]]:
+    """
+    Groups spans into horizontal lines based on their Y-coordinate.
+
+    Args:
+        spans: A list of span dictionaries, each containing a "bbox" key [x0, y0, x1, y1].
+        tolerance: The maximum vertical distance (in points) to consider spans on the same line.
+
+    Returns:
+        A list of clusters, where each cluster is a list of spans sorted by X-coordinate.
+    """
+    if not spans:
+        return []
+
+    # Sort spans by y0 (top coordinate)
+    sorted_spans = sorted(spans, key=lambda s: s["bbox"][1])
+
+    clusters = []
+    current_cluster = [sorted_spans[0]]
+    reference_y = sorted_spans[0]["bbox"][1]
+
+    for i in range(1, len(sorted_spans)):
+        span = sorted_spans[i]
+        if abs(span["bbox"][1] - reference_y) <= tolerance:
+            current_cluster.append(span)
+        else:
+            # Sort the completed cluster by x0
+            current_cluster.sort(key=lambda s: s["bbox"][0])
+            clusters.append(current_cluster)
+            # Start new cluster
+            current_cluster = [span]
+            reference_y = span["bbox"][1]
+
+    # Sort and add the last cluster
+    current_cluster.sort(key=lambda s: s["bbox"][0])
+    clusters.append(current_cluster)
+
+    return clusters
 
 def calculate_base_size(spans: Iterable[Dict[str, Any]]) -> float:
     """

--- a/engine/tests/test_heuristics.py
+++ b/engine/tests/test_heuristics.py
@@ -1,5 +1,52 @@
 import pytest
-from codex_engine.heuristics import calculate_base_size
+from codex_engine.heuristics import calculate_base_size, cluster_spans_by_y
+
+def test_cluster_spans_by_y_basic():
+    spans = [
+        {"text": "World", "bbox": [100, 10, 150, 20]},
+        {"text": "Hello", "bbox": [10, 10, 60, 20]},
+        {"text": "Line 2", "bbox": [10, 30, 60, 40]},
+    ]
+    clusters = cluster_spans_by_y(spans)
+
+    assert len(clusters) == 2
+    # First cluster (Line 1) should have Hello then World (sorted by x0)
+    assert clusters[0][0]["text"] == "Hello"
+    assert clusters[0][1]["text"] == "World"
+    # Second cluster (Line 2)
+    assert clusters[1][0]["text"] == "Line 2"
+
+def test_cluster_spans_by_y_tolerance():
+    spans = [
+        {"text": "Span 1", "bbox": [10, 10, 60, 20]},
+        {"text": "Span 2", "bbox": [70, 11.5, 120, 21.5]}, # Within 2.0 tolerance
+        {"text": "Span 3", "bbox": [10, 12.0, 60, 22.0]}, # Exactly 2.0 tolerance from reference (10.0)
+        {"text": "Span 4", "bbox": [10, 15.0, 60, 25.0]}, # Outside tolerance of reference (10.0)
+    ]
+    clusters = cluster_spans_by_y(spans, tolerance=2.0)
+
+    assert len(clusters) == 2
+    assert len(clusters[0]) == 3
+    assert len(clusters[1]) == 1
+    assert clusters[1][0]["text"] == "Span 4"
+
+def test_cluster_spans_by_y_out_of_order():
+    spans = [
+        {"text": "Bottom", "bbox": [10, 50, 60, 60]},
+        {"text": "Top", "bbox": [10, 10, 60, 20]},
+    ]
+    clusters = cluster_spans_by_y(spans)
+    assert clusters[0][0]["text"] == "Top"
+    assert clusters[1][0]["text"] == "Bottom"
+
+def test_cluster_spans_by_y_empty():
+    assert cluster_spans_by_y([]) == []
+
+def test_cluster_spans_by_y_single():
+    span = {"text": "Single", "bbox": [10, 10, 60, 20]}
+    clusters = cluster_spans_by_y([span])
+    assert len(clusters) == 1
+    assert clusters[0][0]["text"] == "Single"
 
 def test_calculate_base_size_mode():
     spans = [

--- a/engine/tests/test_heuristics.py
+++ b/engine/tests/test_heuristics.py
@@ -20,8 +20,8 @@ def test_cluster_spans_by_y_tolerance():
     spans = [
         {"text": "Span 1", "bbox": [10, 10, 60, 20]},
         {"text": "Span 2", "bbox": [70, 11.5, 120, 21.5]}, # Within 2.0 tolerance
-        {"text": "Span 3", "bbox": [10, 12.0, 60, 22.0]}, # Exactly 2.0 tolerance from reference (10.0)
-        {"text": "Span 4", "bbox": [10, 15.0, 60, 25.0]}, # Outside tolerance of reference (10.0)
+        {"text": "Span 3", "bbox": [10, 12.0, 60, 22.0]}, # Within tolerance of Span 1 (ref) and Span 2 (sliding)
+        {"text": "Span 4", "bbox": [10, 15.0, 60, 25.0]}, # Outside tolerance
     ]
     clusters = cluster_spans_by_y(spans, tolerance=2.0)
 
@@ -29,6 +29,32 @@ def test_cluster_spans_by_y_tolerance():
     assert len(clusters[0]) == 3
     assert len(clusters[1]) == 1
     assert clusters[1][0]["text"] == "Span 4"
+
+def test_cluster_spans_by_y_sliding_reference():
+    # Demonstrates that sliding reference allows handling vertical drift
+    # Span 1 (10) -> Span 2 (11.5) -> Span 3 (13.0) -> Span 4 (14.5)
+    # Each is within 2.0 of its immediate predecessor, but Span 4 is 4.5 from Span 1.
+    spans = [
+        {"text": "1", "bbox": [0, 10.0, 0, 0]},
+        {"text": "2", "bbox": [0, 11.5, 0, 0]},
+        {"text": "3", "bbox": [0, 13.0, 0, 0]},
+        {"text": "4", "bbox": [0, 14.5, 0, 0]},
+    ]
+    clusters = cluster_spans_by_y(spans, tolerance=2.0)
+    assert len(clusters) == 1
+    assert len(clusters[0]) == 4
+
+def test_cluster_spans_by_y_malformed_input():
+    # Missing bbox
+    with pytest.raises(KeyError):
+        cluster_spans_by_y([{"text": "no bbox"}])
+    # Empty bbox (IndexError for bbox[1])
+    with pytest.raises(IndexError):
+        cluster_spans_by_y([{"bbox": []}])
+
+def test_cluster_spans_by_y_negative_tolerance():
+    with pytest.raises(ValueError, match="Tolerance must be non-negative"):
+        cluster_spans_by_y([], tolerance=-1.0)
 
 def test_cluster_spans_by_y_out_of_order():
     spans = [


### PR DESCRIPTION
I've implemented the `cluster_spans_by_y` function in `engine/codex_engine/heuristics.py` as requested. This function is a key component for reconstructing lines from individual text spans during PDF layout analysis. It groups spans that fall within a vertical tolerance (default 2.0 points) and sorts the spans within each resulting group by their X-coordinate. I also added a suite of unit tests to ensure the robustness of the implementation across various scenarios. All tests in the `engine` project are passing.

Fixes #9

---
*PR created automatically by Jules for task [6401394087764961890](https://jules.google.com/task/6401394087764961890) started by @anderson-timana*