### PR TITLE
Implement State Management (Nano Stores) in Reader

### DIFF
--- a/reader/package-lock.json
+++ b/reader/package-lock.json
@@ -9,11 +9,13 @@
       "version": "0.0.1",
       "dependencies": {
         "@astrojs/react": "^5.0.2",
+        "@nanostores/react": "^1.1.0",
         "@tailwindcss/vite": "^4.2.2",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "astro": "^6.1.3",
         "lucide-react": "^1.7.0",
+        "nanostores": "^1.2.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "tailwindcss": "^4.2.2"
@@ -1425,6 +1427,25 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@nanostores/react": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@nanostores/react/-/react-1.1.0.tgz",
+      "integrity": "sha512-MbH35fjhcf7LAubYX5vhOChYUfTLzNLqH/mBGLVsHkcvjy0F8crO1WQwdmQ2xKbAmtpalDa2zBt3Hlg5kqr8iw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": "^20.0.0 || >=22.0.0"
+      },
+      "peerDependencies": {
+        "nanostores": "^1.2.0",
+        "react": ">=18.0.0"
       }
     },
     "node_modules/@oslojs/encoding": {
@@ -4645,6 +4666,21 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/nanostores": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/nanostores/-/nanostores-1.2.0.tgz",
+      "integrity": "sha512-F0wCzbsH80G7XXo0Jd9/AVQC7ouWY6idUCTnMwW5t/Rv9W8qmO6endavDwg7TNp5GbugwSukFMVZqzPSrSMndg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": "^20.0.0 || >=22.0.0"
       }
     },
     "node_modules/neotraverse": {

--- a/reader/package.json
+++ b/reader/package.json
@@ -13,11 +13,13 @@
   },
   "dependencies": {
     "@astrojs/react": "^5.0.2",
+    "@nanostores/react": "^1.1.0",
     "@tailwindcss/vite": "^4.2.2",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "astro": "^6.1.3",
     "lucide-react": "^1.7.0",
+    "nanostores": "^1.2.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "tailwindcss": "^4.2.2"

--- a/reader/src/stores/codexStore.ts
+++ b/reader/src/stores/codexStore.ts
@@ -1,0 +1,18 @@
+import { atom } from 'nanostores';
+
+/**
+ * Global UI state for the Reader application.
+ * Using Nano Stores for lightweight, framework-agnostic state management.
+ */
+
+// Theme state: 'light' or 'dark'
+export const $theme = atom<'light' | 'dark'>('light');
+
+// Reading progress: 0 to 100 representing percentage
+export const $readingProgress = atom<number>(0);
+
+// Current page number (if applicable)
+export const $currentPage = atom<number>(1);
+
+// Sidebar visibility state
+export const $isSidebarOpen = atom<boolean>(false);

--- a/reader/src/stores/codexStore.ts
+++ b/reader/src/stores/codexStore.ts
@@ -1,18 +1,50 @@
 import { atom } from 'nanostores';
+import type { ReadableAtom } from 'nanostores';
 
 /**
  * Global UI state for the Reader application.
  * Using Nano Stores for lightweight, framework-agnostic state management.
  */
 
-// Theme state: 'light' or 'dark'
-export const $theme = atom<'light' | 'dark'>('light');
+// --- Theme ---
 
-// Reading progress: 0 to 100 representing percentage
-export const $readingProgress = atom<number>(0);
+const prefersDark =
+  typeof window !== 'undefined' &&
+  window.matchMedia('(prefers-color-scheme: dark)').matches;
 
-// Current page number (if applicable)
+/** Theme state: 'light' or 'dark'. Initialized from system preference if available. */
+export const $theme = atom<'light' | 'dark'>(prefersDark ? 'dark' : 'light');
+
+// --- Reading Progress ---
+
+// Private — not exported
+const _readingProgress = atom<number>(0);
+
+/** Reading progress percentage (0–100). Read-only externally; write via setReadingProgress(). */
+export const $readingProgress: ReadableAtom<number> = _readingProgress;
+
+/**
+ * Sets the reading progress, clamping the value to the range [0, 100].
+ * @param value - The new progress value. Values outside [0, 100] are clamped.
+ */
+export function setReadingProgress(value: number): void {
+  _readingProgress.set(Math.max(0, Math.min(100, value)));
+}
+
+// --- Navigation & Layout ---
+
+/**
+ * Current page number (1-indexed).
+ * Shared across separate Astro islands (reading view and navigation controls)
+ * that cannot share state via useState across React root boundaries.
+ * @see Issue #44 — Reader: Build Page Navigation Island
+ */
 export const $currentPage = atom<number>(1);
 
-// Sidebar visibility state
+/**
+ * Sidebar open/closed state.
+ * Shared between the SidebarToggle island (header) and the Sidebar island (content area),
+ * which are separate React roots and cannot share state via useState.
+ * @see Issue #45 — Reader: Build Sidebar Island
+ */
 export const $isSidebarOpen = atom<boolean>(false);


### PR DESCRIPTION
Implemented state management in the Reader project using Nano Stores. This setup provides a lightweight, framework-agnostic way to share global UI state between React islands in the Astro project. Included states are theme, reading progress, current page, and sidebar visibility. verified that the project builds correctly with the new dependencies.

Fixes #13

---
*PR created automatically by Jules for task [14627514549711358770](https://jules.google.com/task/14627514549711358770) started by @anderson-timana*