### PR TITLE
Create Typography Components (Astro)

### DIFF
--- a/reader/src/components/blocks/Heading.astro
+++ b/reader/src/components/blocks/Heading.astro
@@ -1,0 +1,49 @@
+---
+interface Props {
+  level: 1 | 2 | 3 | 4 | 5 | 6 | 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+  content: string;
+  style?: {
+    font_size?: number;
+    font_weight?: string;
+    line_height?: number;
+    color?: string;
+    text_align?: string;
+    margin_top?: number;
+    margin_bottom?: number;
+    font_family?: string;
+    text_decoration?: string;
+    font_style?: string;
+  };
+}
+
+const { level, content, style } = Astro.props;
+
+const Tag = (typeof level === 'number' ? `h${level}` : level) as 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+
+const baseStyles: Record<string, string> = {
+  h1: 'text-4xl font-bold tracking-tight text-gray-900',
+  h2: 'text-3xl font-semibold tracking-tight text-gray-900',
+  h3: 'text-2xl font-semibold text-gray-900',
+  h4: 'text-xl font-semibold text-gray-900',
+  h5: 'text-lg font-medium text-gray-900',
+  h6: 'text-base font-medium text-gray-900',
+};
+
+const inlineStyles: Record<string, any> = {};
+if (style) {
+  if (style.font_size !== undefined) inlineStyles['font-size'] = `${style.font_size}px`;
+  if (style.font_weight !== undefined) inlineStyles['font-weight'] = style.font_weight;
+  if (style.line_height !== undefined) inlineStyles['line-height'] = style.line_height;
+  if (style.color !== undefined) inlineStyles['color'] = style.color;
+  if (style.text_align !== undefined) inlineStyles['text-align'] = style.text_align;
+  if (style.margin_top !== undefined) inlineStyles['margin-top'] = `${style.margin_top}px`;
+  if (style.margin_bottom !== undefined) inlineStyles['margin-bottom'] = `${style.margin_bottom}px`;
+  if (style.font_family !== undefined) inlineStyles['font-family'] = style.font_family;
+  if (style.text_decoration !== undefined) inlineStyles['text-decoration'] = style.text_decoration;
+  if (style.font_style !== undefined) inlineStyles['font-style'] = style.font_style;
+}
+---
+
+<Tag class={baseStyles[Tag]} style={inlineStyles}>
+  {content}
+</Tag>

--- a/reader/src/components/blocks/Heading.astro
+++ b/reader/src/components/blocks/Heading.astro
@@ -29,11 +29,11 @@ const baseStyles: Record<string, string> = {
   h6: 'text-base font-medium text-gray-900',
 };
 
-const inlineStyles: Record<string, any> = {};
+const inlineStyles: Record<string, string> = {};
 if (style) {
   if (style.font_size !== undefined) inlineStyles['font-size'] = `${style.font_size}px`;
   if (style.font_weight !== undefined) inlineStyles['font-weight'] = style.font_weight;
-  if (style.line_height !== undefined) inlineStyles['line-height'] = style.line_height;
+  if (style.line_height !== undefined) inlineStyles['line-height'] = String(style.line_height);
   if (style.color !== undefined) inlineStyles['color'] = style.color;
   if (style.text_align !== undefined) inlineStyles['text-align'] = style.text_align;
   if (style.margin_top !== undefined) inlineStyles['margin-top'] = `${style.margin_top}px`;

--- a/reader/src/components/blocks/Paragraph.astro
+++ b/reader/src/components/blocks/Paragraph.astro
@@ -17,11 +17,11 @@ interface Props {
 
 const { content, style } = Astro.props;
 
-const inlineStyles: Record<string, any> = {};
+const inlineStyles: Record<string, string> = {};
 if (style) {
   if (style.font_size !== undefined) inlineStyles['font-size'] = `${style.font_size}px`;
   if (style.font_weight !== undefined) inlineStyles['font-weight'] = style.font_weight;
-  if (style.line_height !== undefined) inlineStyles['line-height'] = style.line_height;
+  if (style.line_height !== undefined) inlineStyles['line-height'] = String(style.line_height);
   if (style.color !== undefined) inlineStyles['color'] = style.color;
   if (style.text_align !== undefined) inlineStyles['text-align'] = style.text_align;
   if (style.margin_top !== undefined) inlineStyles['margin-top'] = `${style.margin_top}px`;

--- a/reader/src/components/blocks/Paragraph.astro
+++ b/reader/src/components/blocks/Paragraph.astro
@@ -1,0 +1,37 @@
+---
+interface Props {
+  content: string;
+  style?: {
+    font_size?: number;
+    font_weight?: string;
+    line_height?: number;
+    color?: string;
+    text_align?: string;
+    margin_top?: number;
+    margin_bottom?: number;
+    font_family?: string;
+    text_decoration?: string;
+    font_style?: string;
+  };
+}
+
+const { content, style } = Astro.props;
+
+const inlineStyles: Record<string, any> = {};
+if (style) {
+  if (style.font_size !== undefined) inlineStyles['font-size'] = `${style.font_size}px`;
+  if (style.font_weight !== undefined) inlineStyles['font-weight'] = style.font_weight;
+  if (style.line_height !== undefined) inlineStyles['line-height'] = style.line_height;
+  if (style.color !== undefined) inlineStyles['color'] = style.color;
+  if (style.text_align !== undefined) inlineStyles['text-align'] = style.text_align;
+  if (style.margin_top !== undefined) inlineStyles['margin-top'] = `${style.margin_top}px`;
+  if (style.margin_bottom !== undefined) inlineStyles['margin-bottom'] = `${style.margin_bottom}px`;
+  if (style.font_family !== undefined) inlineStyles['font-family'] = style.font_family;
+  if (style.text_decoration !== undefined) inlineStyles['text-decoration'] = style.text_decoration;
+  if (style.font_style !== undefined) inlineStyles['font-style'] = style.font_style;
+}
+---
+
+<p class="text-base leading-relaxed text-gray-700" style={inlineStyles}>
+  {content}
+</p>

--- a/reader/src/pages/test-typography.astro
+++ b/reader/src/pages/test-typography.astro
@@ -1,0 +1,51 @@
+---
+import Heading from '../components/blocks/Heading.astro';
+import Paragraph from '../components/blocks/Paragraph.astro';
+import '../styles/global.css';
+---
+
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width" />
+    <title>Typography Test</title>
+  </head>
+  <body class="max-w-4xl mx-auto p-8 bg-white">
+    <section class="space-y-8">
+      <div>
+        <Heading level={1} content="Heading 1" />
+        <Heading level={2} content="Heading 2" />
+        <Heading level={3} content="Heading 3" />
+        <Heading level={4} content="Heading 4" />
+        <Heading level={5} content="Heading 5" />
+        <Heading level={6} content="Heading 6" />
+      </div>
+
+      <hr class="border-gray-200" />
+
+      <div>
+        <Heading level="h2" content="Paragraph Section" />
+        <Paragraph content="This is a standard paragraph with default styles. It should be easy to read and have appropriate line height." />
+        <Paragraph
+          content="This paragraph has custom styles applied via props."
+          style={{ color: '#2563eb', font_weight: 'bold', font_style: 'italic' }}
+        />
+      </div>
+
+      <hr class="border-gray-200" />
+
+      <div>
+        <Heading level="h2" content="Advanced Styling" />
+        <Heading
+          level={3}
+          content="Heading with custom font size and margin"
+          style={{ font_size: 48, margin_top: 40, margin_bottom: 20, text_align: 'center' }}
+        />
+        <Paragraph
+          content="This paragraph is center-aligned and has a larger margin top."
+          style={{ text_align: 'center', margin_top: 24 }}
+        />
+      </div>
+    </section>
+  </body>
+</html>


### PR DESCRIPTION
Created atomic typography components for the Reader application using Astro and Tailwind CSS. 
The components (`Heading.astro` and `Paragraph.astro`) are designed to be "Zero-JS" by default, rendering entirely on the server. 
They support structured style overrides based on the Project Codex specification.
Verified with a build check (no JS bundled) and visual inspection via Playwright.

Fixes #14

---
*PR created automatically by Jules for task [17028165339503774750](https://jules.google.com/task/17028165339503774750) started by @anderson-timana*