### PR TITLE
Reader: Build Sidebar Island using $isSidebarOpen store

### DIFF
--- a/reader/src/components/Sidebar.tsx
+++ b/reader/src/components/Sidebar.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { useStore } from '@nanostores/react';
 import { $isSidebarOpen, $currentPage } from '../stores/codexStore';
 import { X } from 'lucide-react';
@@ -20,9 +20,14 @@ interface SidebarProps {
 export const Sidebar: React.FC<SidebarProps> = ({ chapters }) => {
   const isOpen = useStore($isSidebarOpen);
   const currentPage = useStore($currentPage);
+  const isFirstRender = useRef(true);
 
-  // Close sidebar when page changes
+  // Close sidebar when page changes, but skip the first render
   useEffect(() => {
+    if (isFirstRender.current) {
+      isFirstRender.current = false;
+      return;
+    }
     $isSidebarOpen.set(false);
   }, [currentPage]);
 

--- a/reader/src/components/Sidebar.tsx
+++ b/reader/src/components/Sidebar.tsx
@@ -1,0 +1,79 @@
+import React, { useEffect } from 'react';
+import { useStore } from '@nanostores/react';
+import { $isSidebarOpen, $currentPage } from '../stores/codexStore';
+import { X } from 'lucide-react';
+
+interface Chapter {
+  title: string;
+  page: number;
+}
+
+interface SidebarProps {
+  chapters: Chapter[];
+}
+
+/**
+ * Sidebar component.
+ * Displays a table of contents and subscribes to $isSidebarOpen.
+ * Closes automatically when $currentPage changes.
+ */
+export const Sidebar: React.FC<SidebarProps> = ({ chapters }) => {
+  const isOpen = useStore($isSidebarOpen);
+  const currentPage = useStore($currentPage);
+
+  // Close sidebar when page changes
+  useEffect(() => {
+    $isSidebarOpen.set(false);
+  }, [currentPage]);
+
+  return (
+    <>
+      {/* Overlay */}
+      <div
+        className={`fixed inset-0 bg-black/50 z-40 transition-opacity duration-300 ${
+          isOpen ? 'opacity-100' : 'opacity-0 pointer-events-none'
+        }`}
+        onClick={() => $isSidebarOpen.set(false)}
+      />
+
+      {/* Sidebar Panel */}
+      <aside
+        className={`fixed inset-y-0 left-0 w-64 bg-white dark:bg-gray-900 shadow-xl z-50 transform transition-transform duration-300 ease-in-out p-4 border-r border-gray-200 dark:border-gray-800 ${
+          isOpen ? 'translate-x-0' : '-translate-x-full'
+        }`}
+      >
+        <div className="flex justify-between items-center mb-6">
+          <h2 className="text-xl font-bold">Table of Contents</h2>
+          <button
+            onClick={() => $isSidebarOpen.set(false)}
+            className="p-1 rounded-md hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors cursor-pointer"
+            aria-label="Close sidebar"
+          >
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+        <nav>
+          <ul className="space-y-1">
+            {chapters.map((chapter, index) => (
+              <li key={index}>
+                <button
+                  onClick={() => {
+                    $currentPage.set(chapter.page);
+                  }}
+                  className={`w-full text-left px-3 py-2 hover:bg-gray-100 dark:hover:bg-gray-800 rounded transition-colors flex justify-between items-center ${
+                    currentPage === chapter.page ? 'font-bold bg-gray-50 dark:bg-gray-800 text-blue-600 dark:text-blue-400' : ''
+                  }`}
+                >
+                  <span className="truncate mr-2">{chapter.title}</span>
+                  <span className="text-gray-500 text-xs flex-shrink-0">p. {chapter.page}</span>
+                </button>
+              </li>
+            ))}
+          </ul>
+        </nav>
+      </aside>
+    </>
+  );
+};
+
+export default Sidebar;

--- a/reader/src/components/SidebarToggle.tsx
+++ b/reader/src/components/SidebarToggle.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { useStore } from '@nanostores/react';
+import { $isSidebarOpen } from '../stores/codexStore';
+import { Menu } from 'lucide-react';
+
+/**
+ * SidebarToggle component.
+ * Toggles the visibility of the sidebar using the $isSidebarOpen Nano Store.
+ * This is an Astro island hydrated with React.
+ */
+export const SidebarToggle: React.FC = () => {
+  const isOpen = useStore($isSidebarOpen);
+
+  return (
+    <button
+      onClick={() => $isSidebarOpen.set(!isOpen)}
+      className="p-2 rounded-md hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors cursor-pointer"
+      aria-label={isOpen ? 'Close sidebar' : 'Open sidebar'}
+    >
+      <Menu className="w-6 h-6" />
+    </button>
+  );
+};
+
+export default SidebarToggle;

--- a/reader/src/pages/index.astro
+++ b/reader/src/pages/index.astro
@@ -1,5 +1,14 @@
 ---
 import '../styles/global.css';
+import { SidebarToggle } from '../components/SidebarToggle';
+import { Sidebar } from '../components/Sidebar';
+
+const mockChapters = [
+  { title: 'Introduction', page: 1 },
+  { title: 'Chapter 1: Getting Started', page: 5 },
+  { title: 'Chapter 2: Advanced Topics', page: 12 },
+  { title: 'Conclusion', page: 20 },
+];
 ---
 
 <html lang="en">
@@ -9,9 +18,29 @@ import '../styles/global.css';
 		<link rel="icon" href="/favicon.ico" />
 		<meta name="viewport" content="width=device-width" />
 		<meta name="generator" content={Astro.generator} />
-		<title>Astro</title>
+		<title>Codex Reader</title>
 	</head>
-	<body>
-		<h1>Astro</h1>
+	<body class="bg-gray-50 dark:bg-gray-950 text-gray-900 dark:text-gray-100 min-h-screen">
+		<header class="sticky top-0 z-30 bg-white/80 dark:bg-gray-900/80 backdrop-blur-md border-b border-gray-200 dark:border-gray-800 px-4 h-16 flex items-center justify-between">
+			<div class="flex items-center gap-4">
+				<SidebarToggle client:visible />
+				<h1 class="text-xl font-bold tracking-tight">Codex</h1>
+			</div>
+		</header>
+
+		<Sidebar client:visible chapters={mockChapters} />
+
+		<main class="max-w-3xl mx-auto py-12 px-6">
+			<section class="space-y-6">
+				<h2 class="text-3xl font-extrabold tracking-tight lg:text-4xl">Sample Document</h2>
+				<p class="text-lg text-gray-600 dark:text-gray-400 leading-relaxed">
+					This is a sample page to demonstrate the Sidebar and SidebarToggle islands.
+					Click the hamburger menu in the top-left to open the Table of Contents.
+				</p>
+				<div class="p-8 border-2 border-dashed border-gray-200 dark:border-gray-800 rounded-xl text-center">
+					<p class="text-gray-500 italic">Reading content area...</p>
+				</div>
+			</section>
+		</main>
 	</body>
 </html>

--- a/reader/src/pages/index.astro
+++ b/reader/src/pages/index.astro
@@ -23,12 +23,12 @@ const mockChapters = [
 	<body class="bg-gray-50 dark:bg-gray-950 text-gray-900 dark:text-gray-100 min-h-screen">
 		<header class="sticky top-0 z-30 bg-white/80 dark:bg-gray-900/80 backdrop-blur-md border-b border-gray-200 dark:border-gray-800 px-4 h-16 flex items-center justify-between">
 			<div class="flex items-center gap-4">
-				<SidebarToggle client:visible />
+				<SidebarToggle client:load />
 				<h1 class="text-xl font-bold tracking-tight">Codex</h1>
 			</div>
 		</header>
 
-		<Sidebar client:visible chapters={mockChapters} />
+		<Sidebar client:load chapters={mockChapters} />
 
 		<main class="max-w-3xl mx-auto py-12 px-6">
 			<section class="space-y-6">


### PR DESCRIPTION
Implemented the sidebar (table of contents) and its toggle button as separate Astro islands. They communicate via the `$isSidebarOpen` Nano Store. The sidebar also subscribes to `$currentPage` to automatically close when the user navigates to a new page. Added a sample implementation in `index.astro` with mock chapter data for demonstration.

Fixes #45

---
*PR created automatically by Jules for task [4792652713726357037](https://jules.google.com/task/4792652713726357037) started by @anderson-timana*