### PR TITLE
Implement Recursive Renderer (Astro)

### DIFF
--- a/reader/src/components/CodexRenderer.astro
+++ b/reader/src/components/CodexRenderer.astro
@@ -23,7 +23,7 @@ const { blocks } = Astro.props;
       case 'h6':
         return (
           <Heading
-            level={block.level || parseInt(block.type.substring(1)) as any}
+            level={block.level || (parseInt(block.type[1]) as 1 | 2 | 3 | 4 | 5 | 6)}
             content={block.content || ''}
             style={block.style}
           />
@@ -41,14 +41,14 @@ const { blocks } = Astro.props;
             src={block.src || ''}
             alt={block.alt || ''}
             aspectRatio={block.aspect_ratio}
-            style={block.style as any}
+            style={block.style}
           />
         );
       case 'widget':
         return (
           <Widget
-            client:visible
-            type={block.properties?.widget_type || 'default'}
+            client:load
+            type={(block.properties?.widget_type as string) || 'default'}
             properties={block.properties}
             style={block.style}
           />

--- a/reader/src/components/CodexRenderer.astro
+++ b/reader/src/components/CodexRenderer.astro
@@ -1,0 +1,60 @@
+---
+import Heading from './blocks/Heading.astro';
+import Paragraph from './blocks/Paragraph.astro';
+import BookImage from './blocks/BookImage.astro';
+import Widget from './blocks/Widget.tsx';
+import type { CodexBlock } from '../types/codex';
+
+interface Props {
+  blocks: CodexBlock[];
+}
+
+const { blocks } = Astro.props;
+---
+
+<div class="codex-content space-y-4">
+  {blocks.map((block) => {
+    switch (block.type) {
+      case 'h1':
+      case 'h2':
+      case 'h3':
+      case 'h4':
+      case 'h5':
+      case 'h6':
+        return (
+          <Heading
+            level={block.level || parseInt(block.type.substring(1)) as any}
+            content={block.content || ''}
+            style={block.style}
+          />
+        );
+      case 'p':
+        return (
+          <Paragraph
+            content={block.content || ''}
+            style={block.style}
+          />
+        );
+      case 'image':
+        return (
+          <BookImage
+            src={block.src || ''}
+            alt={block.alt || ''}
+            aspectRatio={block.aspect_ratio}
+            style={block.style as any}
+          />
+        );
+      case 'widget':
+        return (
+          <Widget
+            client:visible
+            type={block.properties?.widget_type || 'default'}
+            properties={block.properties}
+            style={block.style}
+          />
+        );
+      default:
+        return <div class="bg-red-50 text-red-500 p-4 rounded">Unknown block type: {block.type}</div>;
+    }
+  })}
+</div>

--- a/reader/src/components/blocks/Widget.tsx
+++ b/reader/src/components/blocks/Widget.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { snakeToCamel } from '../../utils/styleUtils';
+
+interface WidgetProps {
+  type: string;
+  properties?: Record<string, any>;
+  style?: Record<string, any>;
+}
+
+const Widget: React.FC<WidgetProps> = ({ type, properties, style }) => {
+  const camelStyle = snakeToCamel(style);
+
+  return (
+    <div
+      className="p-8 border-2 border-dashed border-purple-200 rounded-xl bg-purple-50/50 flex flex-col items-center justify-center text-center space-y-2 my-8"
+      style={camelStyle}
+    >
+      <div className="text-purple-500 font-medium">Interactive Widget Placeholder</div>
+      <div className="text-sm text-gray-500 max-w-sm">
+        This is an interactive widget powered by React.
+        {type && <span> Type: <code className="bg-purple-100 px-1 rounded">{type}</code></span>}
+      </div>
+      {properties && Object.keys(properties).length > 0 && (
+        <div className="mt-4 text-xs text-left w-full bg-white p-2 rounded border border-purple-100">
+          <div className="font-bold mb-1">Properties:</div>
+          <pre>{JSON.stringify(properties, null, 2)}</pre>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default Widget;

--- a/reader/src/components/blocks/Widget.tsx
+++ b/reader/src/components/blocks/Widget.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import { snakeToCamel } from '../../utils/styleUtils';
+import type { CodexStyle } from '../../types/codex';
 
 interface WidgetProps {
   type: string;
-  properties?: Record<string, any>;
-  style?: Record<string, any>;
+  properties?: Record<string, unknown>;
+  style?: CodexStyle;
 }
 
 const Widget: React.FC<WidgetProps> = ({ type, properties, style }) => {

--- a/reader/src/fixtures/mock_manifest.json
+++ b/reader/src/fixtures/mock_manifest.json
@@ -1,4 +1,5 @@
 {
+  "version": "1.0",
   "meta": {
     "title": "The Art of Codex",
     "author": "Jules",
@@ -55,6 +56,9 @@
       "id": "550e8400-e29b-41d4-a716-446655440004",
       "type": "widget",
       "content": "This is an interactive widget powered by React.",
+      "properties": {
+        "widget_type": "info_card"
+      },
       "style": {
         "margin_top": 10
       },

--- a/reader/src/mock_manifest.json
+++ b/reader/src/mock_manifest.json
@@ -1,0 +1,65 @@
+{
+  "meta": {
+    "title": "The Art of Codex",
+    "author": "Jules",
+    "description": "A deep dive into the architecture of Project Codex.",
+    "base_size": 16.0,
+    "seo": {
+      "title": "SEO Optimized Art of Codex",
+      "description": "Learn all about Project Codex with this SEO-friendly guide.",
+      "keywords": ["codex", "astro", "renderer", "pwa"]
+    }
+  },
+  "blocks": [
+    {
+      "id": "550e8400-e29b-41d4-a716-446655440000",
+      "type": "h1",
+      "content": "Welcome to Project Codex",
+      "style": {
+        "text_align": "center",
+        "margin_bottom": 40
+      },
+      "bbox": { "x0": 0, "y0": 0, "x1": 100, "y1": 20 }
+    },
+    {
+      "id": "550e8400-e29b-41d4-a716-446655440001",
+      "type": "p",
+      "content": "This is a paragraph demonstrating the static rendering capabilities of the Astro renderer. Zero JS is shipped for this text.",
+      "style": {
+        "line_height": 1.6
+      },
+      "bbox": { "x0": 0, "y0": 25, "x1": 100, "y1": 40 }
+    },
+    {
+      "id": "550e8400-e29b-41d4-a716-446655440002",
+      "type": "image",
+      "src": "https://picsum.photos/seed/codex/1200/800",
+      "alt": "Sample Codex Image",
+      "aspect_ratio": 1.5,
+      "style": {
+        "margin_top": 20,
+        "margin_bottom": 20
+      },
+      "bbox": { "x0": 0, "y0": 45, "x1": 100, "y1": 80 }
+    },
+    {
+      "id": "550e8400-e29b-41d4-a716-446655440003",
+      "type": "h2",
+      "content": "Interactive Features",
+      "style": {
+        "margin_top": 30
+      },
+      "bbox": { "x0": 0, "y0": 85, "x1": 100, "y1": 95 }
+    },
+    {
+      "id": "550e8400-e29b-41d4-a716-446655440004",
+      "type": "widget",
+      "content": "This is an interactive widget powered by React.",
+      "style": {
+        "margin_top": 10
+      },
+      "bbox": { "x0": 0, "y0": 100, "x1": 100, "y1": 120 }
+    }
+  ],
+  "assets": {}
+}

--- a/reader/src/pages/index.astro
+++ b/reader/src/pages/index.astro
@@ -3,7 +3,15 @@ import '../styles/global.css';
 import { SidebarToggle } from '../components/SidebarToggle';
 import { Sidebar } from '../components/Sidebar';
 import { NavigationControls } from '../components/NavigationControls';
-import { ReadingContent } from '../components/ReadingContent';
+import CodexRenderer from '../components/CodexRenderer.astro';
+import mockManifest from '../mock_manifest.json';
+
+const { meta, blocks } = mockManifest;
+
+// SEO Metadata Extraction with Fallbacks
+const seoTitle = meta.seo?.title || meta.title;
+const seoDescription = meta.seo?.description || meta.description;
+const seoKeywords = meta.seo?.keywords?.join(', ');
 
 const mockChapters = [
   { title: 'Introduction', page: 1 },
@@ -20,7 +28,11 @@ const mockChapters = [
 		<link rel="icon" href="/favicon.ico" />
 		<meta name="viewport" content="width=device-width" />
 		<meta name="generator" content={Astro.generator} />
-		<title>Codex Reader</title>
+
+		<!-- SEO Injection -->
+		<title>{seoTitle}</title>
+		<meta name="description" content={seoDescription} />
+		{seoKeywords && <meta name="keywords" content={seoKeywords} />}
 	</head>
 	<body class="bg-gray-50 dark:bg-gray-950 text-gray-900 dark:text-gray-100 min-h-screen">
 		<header class="sticky top-0 z-30 bg-white/80 dark:bg-gray-900/80 backdrop-blur-md border-b border-gray-200 dark:border-gray-800 px-4 h-16 flex items-center justify-between">
@@ -38,7 +50,7 @@ const mockChapters = [
 
 		<main class="max-w-3xl mx-auto py-12 px-6">
 			<section class="space-y-6">
-				<ReadingContent client:load />
+				<CodexRenderer blocks={blocks} />
 			</section>
 		</main>
 	</body>

--- a/reader/src/pages/index.astro
+++ b/reader/src/pages/index.astro
@@ -4,7 +4,7 @@ import { SidebarToggle } from '../components/SidebarToggle';
 import { Sidebar } from '../components/Sidebar';
 import { NavigationControls } from '../components/NavigationControls';
 import CodexRenderer from '../components/CodexRenderer.astro';
-import mockManifest from '../mock_manifest.json';
+import mockManifest from '../fixtures/mock_manifest.json';
 
 const { meta, blocks } = mockManifest;
 
@@ -50,7 +50,7 @@ const mockChapters = [
 
 		<main class="max-w-3xl mx-auto py-12 px-6">
 			<section class="space-y-6">
-				<CodexRenderer blocks={blocks} />
+				<CodexRenderer blocks={blocks as any} />
 			</section>
 		</main>
 	</body>

--- a/reader/src/types/codex.ts
+++ b/reader/src/types/codex.ts
@@ -20,7 +20,7 @@ export interface CodexBlock {
   alt?: string;
   level?: 1 | 2 | 3 | 4 | 5 | 6;
   style?: CodexStyle;
-  properties?: Record<string, any>;
+  properties?: Record<string, unknown>;
   aspect_ratio?: number;
 }
 

--- a/reader/src/types/codex.ts
+++ b/reader/src/types/codex.ts
@@ -1,0 +1,45 @@
+export interface CodexStyle {
+  font_size?: number;
+  font_weight?: string;
+  line_height?: number;
+  color?: string;
+  text_align?: 'left' | 'center' | 'right' | 'justify';
+  margin_top?: number;
+  margin_bottom?: number;
+  font_family?: string;
+  text_decoration?: string;
+  font_style?: string;
+}
+
+export type CodexBlockType = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'p' | 'image' | 'widget';
+
+export interface CodexBlock {
+  type: CodexBlockType;
+  content?: string;
+  src?: string;
+  alt?: string;
+  level?: 1 | 2 | 3 | 4 | 5 | 6;
+  style?: CodexStyle;
+  properties?: Record<string, any>;
+  aspect_ratio?: number;
+}
+
+export interface CodexSEO {
+  title?: string;
+  description?: string;
+  keywords?: string[];
+}
+
+export interface CodexMeta {
+  title: string;
+  description: string;
+  author?: string;
+  date?: string;
+  seo?: CodexSEO;
+}
+
+export interface CodexManifest {
+  version: string;
+  meta: CodexMeta;
+  blocks: CodexBlock[];
+}

--- a/reader/src/utils/styleUtils.ts
+++ b/reader/src/utils/styleUtils.ts
@@ -1,0 +1,18 @@
+/**
+ * Converts snake_case keys of an object to camelCase.
+ * Useful for mapping Codex manifest styles to React style objects.
+ */
+export function snakeToCamel(obj: Record<string, any> | undefined): Record<string, any> {
+  if (!obj) return {};
+
+  const result: Record<string, any> = {};
+
+  for (const key in obj) {
+    if (Object.prototype.hasOwnProperty.call(obj, key)) {
+      const camelKey = key.replace(/(_\w)/g, (m) => m[1].toUpperCase());
+      result[camelKey] = obj[key];
+    }
+  }
+
+  return result;
+}


### PR DESCRIPTION
Implemented a modular renderer for Codex manifests in Astro. This includes a factory component that maps block types to static Astro components or interactive React islands, and dynamic SEO metadata injection in the page head. The renderer supports headings, paragraphs, images (with aspect ratio handling), and custom React widgets.

Fixes #16

---
*PR created automatically by Jules for task [13044644491215105810](https://jules.google.com/task/13044644491215105810) started by @anderson-timana*