### PR TITLE
Admin: Build Book List Widget

### DIFF
--- a/admin/lib/main.dart
+++ b/admin/lib/main.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 import 'core/config.dart';
 import 'screens/login_screen.dart';
+import 'widgets/book_list_view.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -56,9 +57,7 @@ class DashboardScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('Dashboard')),
-      body: const Center(
-        child: Text('Codex Admin Dashboard'),
-      ),
+      body: const BookListView(),
     );
   }
 }

--- a/admin/lib/services/book_repository.dart
+++ b/admin/lib/services/book_repository.dart
@@ -76,3 +76,8 @@ class BookRepository {
 BookRepository bookRepository(BookRepositoryRef ref) {
   return BookRepository(Supabase.instance.client);
 }
+
+@riverpod
+Future<List<Book>> bookList(BookListRef ref) async {
+  return ref.watch(bookRepositoryProvider).getBooks();
+}

--- a/admin/lib/services/book_repository.dart
+++ b/admin/lib/services/book_repository.dart
@@ -79,5 +79,5 @@ BookRepository bookRepository(BookRepositoryRef ref) {
 
 @riverpod
 Future<List<Book>> bookList(BookListRef ref) async {
-  return ref.watch(bookRepositoryProvider).getBooks();
+  return ref.read(bookRepositoryProvider).getBooks();
 }

--- a/admin/lib/widgets/book_card.dart
+++ b/admin/lib/widgets/book_card.dart
@@ -12,7 +12,8 @@ class BookCard extends StatelessWidget {
       margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
       child: ListTile(
         title: Text(book.title),
-        subtitle: Text('Status: ${book.status.name}'),
+        subtitle: Text(
+            'Status: ${book.status.name[0].toUpperCase()}${book.status.name.substring(1)}'),
         trailing: _getStatusIcon(book.status),
       ),
     );

--- a/admin/lib/widgets/book_card.dart
+++ b/admin/lib/widgets/book_card.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart';
+import '../models/book.dart';
+
+class BookCard extends StatelessWidget {
+  final Book book;
+
+  const BookCard({super.key, required this.book});
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      child: ListTile(
+        title: Text(book.title),
+        subtitle: Text('Status: ${book.status.name}'),
+        trailing: _getStatusIcon(book.status),
+      ),
+    );
+  }
+
+  Widget _getStatusIcon(BookStatus status) {
+    switch (status) {
+      case BookStatus.processing:
+        return const SizedBox(
+          width: 20,
+          height: 20,
+          child: CircularProgressIndicator(strokeWidth: 2),
+        );
+      case BookStatus.completed:
+        return const Icon(Icons.check_circle, color: Colors.green);
+      case BookStatus.failed:
+        return const Icon(Icons.error, color: Colors.red);
+    }
+  }
+}

--- a/admin/lib/widgets/book_list_view.dart
+++ b/admin/lib/widgets/book_list_view.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../services/book_repository.dart';
+import 'book_card.dart';
+
+class BookListView extends ConsumerWidget {
+  const BookListView({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final bookListAsync = ref.watch(bookListProvider);
+
+    return bookListAsync.when(
+      data: (books) {
+        if (books.isEmpty) {
+          return const Center(
+            child: Text('No books found. Upload one to get started!'),
+          );
+        }
+        return ListView.builder(
+          itemCount: books.length,
+          itemBuilder: (context, index) {
+            final book = books[index];
+            return BookCard(book: book);
+          },
+        );
+      },
+      loading: () => const Center(child: CircularProgressIndicator()),
+      error: (error, stack) => Center(
+        child: Text('Error loading books: $error'),
+      ),
+    );
+  }
+}

--- a/admin/lib/widgets/book_list_view.dart
+++ b/admin/lib/widgets/book_list_view.dart
@@ -26,8 +26,8 @@ class BookListView extends ConsumerWidget {
         );
       },
       loading: () => const Center(child: CircularProgressIndicator()),
-      error: (error, stack) => Center(
-        child: Text('Error loading books: $error'),
+      error: (error, stack) => const Center(
+        child: Text('Failed to load books. Please try again later.'),
       ),
     );
   }


### PR DESCRIPTION
This PR implements the Book List Widget for the Admin Library Display.

Key changes:
- **bookListProvider**: A new provider in `admin/lib/services/book_repository.dart` that fetches the list of books for the authenticated user.
- **BookCard**: A reusable widget in `admin/lib/widgets/book_card.dart` that displays book information (title, status) with appropriate icons for different statuses (processing, completed, failed).
- **BookListView**: A consumer widget in `admin/lib/widgets/book_list_view.dart` that handles loading, error, and empty states while rendering the list of books using `ListView.builder`.
- **Dashboard Integration**: The `DashboardScreen` now displays the `BookListView` instead of a placeholder.

Verification:
- Ran `flutter analyze` and `flutter test` in the `admin` directory; both passed.
- Verified the existence of generated Riverpod files.

Fixes #21

---
*PR created automatically by Jules for task [12376775752666652629](https://jules.google.com/task/12376775752666652629) started by @anderson-timana*