### PR TITLE
Admin: Build File Picker Widget

### DIFF
--- a/admin/lib/main.dart
+++ b/admin/lib/main.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
@@ -62,7 +63,7 @@ class DashboardScreen extends StatelessWidget {
         children: [
           FileUploadZone(
             onFileSelected: (file) {
-              if (file != null) {
+              if (kDebugMode && file != null) {
                 debugPrint('Selected file: ${file.path}');
               }
             },

--- a/admin/lib/main.dart
+++ b/admin/lib/main.dart
@@ -4,6 +4,7 @@ import 'package:supabase_flutter/supabase_flutter.dart';
 import 'core/config.dart';
 import 'screens/login_screen.dart';
 import 'widgets/book_list_view.dart';
+import 'widgets/file_upload_zone.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -57,7 +58,20 @@ class DashboardScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('Dashboard')),
-      body: const BookListView(),
+      body: Column(
+        children: [
+          FileUploadZone(
+            onFileSelected: (file) {
+              if (file != null) {
+                debugPrint('Selected file: ${file.path}');
+              }
+            },
+          ),
+          const Expanded(
+            child: BookListView(),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/admin/lib/widgets/file_upload_zone.dart
+++ b/admin/lib/widgets/file_upload_zone.dart
@@ -1,0 +1,105 @@
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter/material.dart';
+
+class FileUploadZone extends StatefulWidget {
+  final Function(PlatformFile?) onFileSelected;
+
+  const FileUploadZone({super.key, required this.onFileSelected});
+
+  @override
+  State<FileUploadZone> createState() => _FileUploadZoneState();
+}
+
+class _FileUploadZoneState extends State<FileUploadZone> {
+  PlatformFile? _selectedFile;
+
+  Future<void> _pickFile() async {
+    final result = await FilePicker.platform.pickFiles(
+      type: FileType.custom,
+      allowedExtensions: ['pdf'],
+    );
+
+    if (result != null) {
+      setState(() {
+        _selectedFile = result.files.first;
+      });
+      widget.onFileSelected(_selectedFile);
+    }
+  }
+
+  void _clearFile() {
+    setState(() {
+      _selectedFile = null;
+    });
+    widget.onFileSelected(null);
+  }
+
+  String _formatSize(int bytes) {
+    return '${(bytes / (1024 * 1024)).toStringAsFixed(2)} MB';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: const EdgeInsets.all(16),
+      padding: const EdgeInsets.all(24),
+      decoration: BoxDecoration(
+        border: Border.all(color: Theme.of(context).dividerColor),
+        borderRadius: BorderRadius.circular(12),
+        color: Theme.of(context).colorScheme.surfaceContainerHighest.withValues(alpha: 0.3),
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          if (_selectedFile == null) ...[
+            const Icon(Icons.upload_file, size: 48, color: Colors.grey),
+            const SizedBox(height: 16),
+            const Text(
+              'Select a PDF file to upload',
+              style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 16),
+            ElevatedButton.icon(
+              onPressed: _pickFile,
+              icon: const Icon(Icons.add),
+              label: const Text('Pick File'),
+            ),
+          ] else ...[
+            Row(
+              children: [
+                const Icon(Icons.description, size: 32, color: Colors.blue),
+                const SizedBox(width: 16),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        _selectedFile!.name,
+                        style: const TextStyle(
+                          fontWeight: FontWeight.bold,
+                          fontSize: 14,
+                        ),
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                      Text(
+                        _formatSize(_selectedFile!.size),
+                        style: TextStyle(
+                          color: Colors.grey[600],
+                          fontSize: 12,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                IconButton(
+                  onPressed: _clearFile,
+                  icon: const Icon(Icons.close, color: Colors.red),
+                ),
+              ],
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}

--- a/admin/lib/widgets/file_upload_zone.dart
+++ b/admin/lib/widgets/file_upload_zone.dart
@@ -2,7 +2,7 @@ import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 
 class FileUploadZone extends StatefulWidget {
-  final Function(PlatformFile?) onFileSelected;
+  final void Function(PlatformFile?) onFileSelected;
 
   const FileUploadZone({super.key, required this.onFileSelected});
 
@@ -12,18 +12,26 @@ class FileUploadZone extends StatefulWidget {
 
 class _FileUploadZoneState extends State<FileUploadZone> {
   PlatformFile? _selectedFile;
+  bool _isLoading = false;
 
   Future<void> _pickFile() async {
-    final result = await FilePicker.platform.pickFiles(
-      type: FileType.custom,
-      allowedExtensions: ['pdf'],
-    );
+    setState(() => _isLoading = true);
+    try {
+      final result = await FilePicker.platform.pickFiles(
+        type: FileType.custom,
+        allowedExtensions: ['pdf'],
+      );
 
-    if (result != null) {
-      setState(() {
-        _selectedFile = result.files.first;
-      });
-      widget.onFileSelected(_selectedFile);
+      if (result != null) {
+        setState(() {
+          _selectedFile = result.files.first;
+        });
+        widget.onFileSelected(_selectedFile);
+      }
+    } finally {
+      if (mounted) {
+        setState(() => _isLoading = false);
+      }
     }
   }
 
@@ -35,6 +43,8 @@ class _FileUploadZoneState extends State<FileUploadZone> {
   }
 
   String _formatSize(int bytes) {
+    if (bytes < 1024) return '$bytes B';
+    if (bytes < 1024 * 1024) return '${(bytes / 1024).toStringAsFixed(1)} KB';
     return '${(bytes / (1024 * 1024)).toStringAsFixed(2)} MB';
   }
 
@@ -60,8 +70,14 @@ class _FileUploadZoneState extends State<FileUploadZone> {
             ),
             const SizedBox(height: 16),
             ElevatedButton.icon(
-              onPressed: _pickFile,
-              icon: const Icon(Icons.add),
+              onPressed: _isLoading ? null : _pickFile,
+              icon: _isLoading
+                  ? const SizedBox(
+                      width: 16,
+                      height: 16,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : const Icon(Icons.add),
               label: const Text('Pick File'),
             ),
           ] else ...[

--- a/admin/pubspec.lock
+++ b/admin/pubspec.lock
@@ -217,6 +217,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.2"
+  cross_file:
+    dependency: transitive
+    description:
+      name: cross_file
+      sha256: "28bb3ae56f117b5aec029d702a90f57d285cd975c3c5c281eaca38dbc47c5937"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.5+2"
   crypto:
     dependency: transitive
     description:
@@ -305,6 +313,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.1"
+  file_picker:
+    dependency: "direct main"
+    description:
+      name: file_picker
+      sha256: c904b4ab56d53385563c7c39d8e9fa9af086f91495dfc48717ad84a42c3cf204
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.1.7"
   fixnum:
     dependency: transitive
     description:
@@ -326,6 +342,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.0.0"
+  flutter_plugin_android_lifecycle:
+    dependency: transitive
+    description:
+      name: flutter_plugin_android_lifecycle
+      sha256: "38d1c268de9097ff59cf0e844ac38759fc78f76836d37edad06fa21e182055a0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.34"
   flutter_riverpod:
     dependency: "direct main"
     description:
@@ -1077,6 +1101,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.3"
+  win32:
+    dependency: transitive
+    description:
+      name: win32
+      sha256: d7cb55e04cd34096cd3a79b3330245f54cb96a370a1c27adb3c84b917de8b08e
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.15.0"
   xdg_directories:
     dependency: transitive
     description:

--- a/admin/pubspec.yaml
+++ b/admin/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   supabase_flutter: ^2.8.3
   flutter_riverpod: ^2.6.1
   riverpod_annotation: ^2.6.1
+  file_picker: 8.1.7
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Implemented a new File Picker Widget (`FileUploadZone`) for the admin panel. The widget allows users to select PDF files, displays the selected file's name and size in MB, and provides a clear/cancel option. The widget was integrated into the main Dashboard screen.

Key changes:
- New file: `admin/lib/widgets/file_upload_zone.dart`
- Dependency: Added `file_picker: 8.1.7` to `admin/pubspec.yaml`
- Integration: Added `FileUploadZone` to `DashboardScreen` in `admin/lib/main.dart`
- Generated code: Ran `build_runner` to ensure all Riverpod providers are up to date.

Fixes #22

---
*PR created automatically by Jules for task [1490145771614598739](https://jules.google.com/task/1490145771614598739) started by @anderson-timana*