### PR TITLE
Admin: Integrate PDF Viewer

### DIFF
--- a/admin/lib/screens/editor_screen.dart
+++ b/admin/lib/screens/editor_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:multi_split_view/multi_split_view.dart';
 import '../models/book.dart';
+import '../widgets/pdf_panel.dart';
 
 class EditorScreen extends StatefulWidget {
   const EditorScreen({super.key});
@@ -48,7 +49,7 @@ class _EditorScreenState extends State<EditorScreen> {
           controller: _controller,
           builder: (context, area) {
             if (area.index == 0) {
-              return _buildMainContent();
+              return _buildMainContent(book);
             } else {
               return _buildSettingsSidebar();
             }
@@ -58,10 +59,8 @@ class _EditorScreenState extends State<EditorScreen> {
     );
   }
 
-  Widget _buildMainContent() {
-    return const Center(
-      child: Text('Main Editor Content (60%)'),
-    );
+  Widget _buildMainContent(Book? book) {
+    return PdfPanel(pdfUrl: book?.originalPdfUrl);
   }
 
   Widget _buildSettingsSidebar() {

--- a/admin/lib/widgets/pdf_panel.dart
+++ b/admin/lib/widgets/pdf_panel.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+import 'package:pdfrx/pdfrx.dart';
+
+class PdfPanel extends StatelessWidget {
+  final String? pdfUrl;
+
+  const PdfPanel({super.key, this.pdfUrl});
+
+  @override
+  Widget build(BuildContext context) {
+    if (pdfUrl == null || pdfUrl!.isEmpty) {
+      return const Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(Icons.picture_as_pdf, size: 64, color: Colors.grey),
+            SizedBox(height: 16),
+            Text('No PDF available to display.'),
+          ],
+        ),
+      );
+    }
+
+    return PdfViewer.uri(
+      Uri.parse(pdfUrl!),
+    );
+  }
+}

--- a/admin/pubspec.lock
+++ b/admin/pubspec.lock
@@ -57,6 +57,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.4"
+  archive:
+    dependency: transitive
+    description:
+      name: archive
+      sha256: a96e8b390886ee8abb49b7bd3ac8df6f451c621619f52a26e815fdcf568959ff
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.0.9"
   args:
     dependency: transitive
     description:
@@ -464,6 +472,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.1.2"
+  image:
+    dependency: transitive
+    description:
+      name: image
+      sha256: f9881ff4998044947ec38d098bc7c8316ae1186fa786eddffdb867b9bc94dfce
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.8.0"
   io:
     dependency: transitive
     description:
@@ -672,6 +688,46 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.0"
+  pdfium_dart:
+    dependency: transitive
+    description:
+      name: pdfium_dart
+      sha256: f1683b9070ddc5c9189c6ee008c285791da66328ce1b882c7162d3393f3a4a74
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.3"
+  pdfium_flutter:
+    dependency: transitive
+    description:
+      name: pdfium_flutter
+      sha256: "0c8b7d5d11d20a1486eade599648e907067568955bd14a1b06de076a968b60a1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.9"
+  pdfrx:
+    dependency: "direct main"
+    description:
+      name: pdfrx
+      sha256: e32e0c786528eec2b3c56b43f59ef1debce3a27c7accd862b95413f949afcfa9
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.24"
+  pdfrx_engine:
+    dependency: transitive
+    description:
+      name: pdfrx_engine
+      sha256: a8914433d1f6188b903c53d36b9d7dc908bfa89131591a9db22f1a22470d3a48
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.9"
+  petitparser:
+    dependency: transitive
+    description:
+      name: petitparser
+      sha256: "91bd59303e9f769f108f8df05e371341b15d59e995e6806aefab827b58336675"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.2"
   platform:
     dependency: transitive
     description:
@@ -704,6 +760,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.2"
+  posix:
+    dependency: transitive
+    description:
+      name: posix
+      sha256: "185ef7606574f789b40f289c233efa52e96dead518aed988e040a10737febb07"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.5.0"
   postgrest:
     dependency: transitive
     description:
@@ -957,6 +1021,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.12.4"
+  synchronized:
+    dependency: transitive
+    description:
+      name: synchronized
+      sha256: "63896c27e81b28f8cb4e69ead0d3e8f03f1d1e5fc531a3e579cabed6a2c7c9e5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.4.0+1"
   term_glyph:
     dependency: transitive
     description:
@@ -1125,6 +1197,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
+  xml:
+    dependency: transitive
+    description:
+      name: xml
+      sha256: "971043b3a0d3da28727e40ed3e0b5d18b742fa5a68665cca88e74b7876d5e025"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.6.1"
   yaml:
     dependency: transitive
     description:

--- a/admin/pubspec.yaml
+++ b/admin/pubspec.yaml
@@ -16,6 +16,7 @@ dependencies:
   riverpod_annotation: ^2.6.1
   file_picker: 8.1.7
   multi_split_view: ^3.6.1
+  pdfrx: ^2.2.24
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
This PR integrates a PDF viewer into the Admin Editor Screen.

Key changes:
- Added `pdfrx` package to `pubspec.yaml`.
- Created a reusable `PdfPanel` widget in `admin/lib/widgets/pdf_panel.dart` that uses `PdfViewer.uri` to load and display PDFs.
- Updated `EditorScreen` in `admin/lib/screens/editor_screen.dart` to use `PdfPanel` in its main content area (left pane), passing the `originalPdfUrl` from the `Book` object.
- Fixed static analysis issues by running `build_runner` and removing an unsupported parameter from `PdfViewerParams`.
- Verified changes with `flutter analyze` and `flutter test`.

Fixes #24

---
*PR created automatically by Jules for task [9855639232612907641](https://jules.google.com/task/9855639232612907641) started by @anderson-timana*