### PR TITLE
Implement Editor State Management

### DIFF
--- a/admin/lib/providers/editor_state.dart
+++ b/admin/lib/providers/editor_state.dart
@@ -31,7 +31,7 @@ class EditorState {
           selectedBlockId == other.selectedBlockId;
 
   @override
-  int get hashCode => currentPage.hashCode ^ selectedBlockId.hashCode;
+  int get hashCode => Object.hash(currentPage, selectedBlockId);
 }
 
 @riverpod

--- a/admin/lib/providers/editor_state.dart
+++ b/admin/lib/providers/editor_state.dart
@@ -1,0 +1,55 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'editor_state.g.dart';
+
+class EditorState {
+  final int currentPage;
+  final String? selectedBlockId;
+
+  const EditorState({
+    this.currentPage = 1,
+    this.selectedBlockId,
+  });
+
+  EditorState copyWith({
+    int? currentPage,
+    String? selectedBlockId,
+    bool clearSelectedBlockId = false,
+  }) {
+    return EditorState(
+      currentPage: currentPage ?? this.currentPage,
+      selectedBlockId: clearSelectedBlockId ? null : (selectedBlockId ?? this.selectedBlockId),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is EditorState &&
+          runtimeType == other.runtimeType &&
+          currentPage == other.currentPage &&
+          selectedBlockId == other.selectedBlockId;
+
+  @override
+  int get hashCode => currentPage.hashCode ^ selectedBlockId.hashCode;
+}
+
+@riverpod
+class EditorStateNotifier extends _$EditorStateNotifier {
+  @override
+  EditorState build() {
+    return const EditorState();
+  }
+
+  void setCurrentPage(int page) {
+    state = state.copyWith(currentPage: page);
+  }
+
+  void setSelectedBlockId(String? blockId) {
+    state = state.copyWith(selectedBlockId: blockId);
+  }
+
+  void clearSelection() {
+    state = state.copyWith(clearSelectedBlockId: true);
+  }
+}

--- a/admin/test/providers/editor_state_test.dart
+++ b/admin/test/providers/editor_state_test.dart
@@ -1,0 +1,46 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:admin/providers/editor_state.dart';
+
+void main() {
+  test('EditorStateNotifier should have initial state', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    final state = container.read(editorStateNotifierProvider);
+
+    expect(state.currentPage, 1);
+    expect(state.selectedBlockId, isNull);
+  });
+
+  test('setCurrentPage should update currentPage', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    container.read(editorStateNotifierProvider.notifier).setCurrentPage(5);
+    final state = container.read(editorStateNotifierProvider);
+
+    expect(state.currentPage, 5);
+  });
+
+  test('setSelectedBlockId should update selectedBlockId', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    container.read(editorStateNotifierProvider.notifier).setSelectedBlockId('block-123');
+    final state = container.read(editorStateNotifierProvider);
+
+    expect(state.selectedBlockId, 'block-123');
+  });
+
+  test('clearSelection should nullify selectedBlockId', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    container.read(editorStateNotifierProvider.notifier).setSelectedBlockId('block-123');
+    expect(container.read(editorStateNotifierProvider).selectedBlockId, 'block-123');
+
+    container.read(editorStateNotifierProvider.notifier).clearSelection();
+    expect(container.read(editorStateNotifierProvider).selectedBlockId, isNull);
+  });
+}


### PR DESCRIPTION
Implemented state management for the Admin Editor using Riverpod 2.x.
Created `admin/lib/providers/editor_state.dart` with `EditorStateNotifier` to manage `currentPage` and `selectedBlockId`.
Ran code generation and verified implementation with new unit tests in `admin/test/providers/editor_state_test.dart`.

Fixes #25

---
*PR created automatically by Jules for task [9859803931246830928](https://jules.google.com/task/9859803931246830928) started by @anderson-timana*