### PR TITLE
Frontend: Create YouTube Widget (React Island)

### DIFF
--- a/reader/package-lock.json
+++ b/reader/package-lock.json
@@ -21,9 +21,6 @@
         "react-dom": "^19.2.4",
         "tailwindcss": "^4.2.2"
       },
-      "devDependencies": {
-        "@playwright/test": "^1.59.1"
-      },
       "engines": {
         "node": ">=22.12.0"
       }
@@ -2720,22 +2717,6 @@
       "resolved": "https://registry.npmjs.org/@oslojs/encoding/-/encoding-1.1.0.tgz",
       "integrity": "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==",
       "license": "MIT"
-    },
-    "node_modules/@playwright/test": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
-      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "playwright": "1.59.1"
-      },
-      "bin": {
-        "playwright": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      }
     },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-rc.3",
@@ -7899,53 +7880,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/playwright": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
-      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "playwright-core": "1.59.1"
-      },
-      "bin": {
-        "playwright": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "fsevents": "2.3.2"
-      }
-    },
-    "node_modules/playwright-core": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
-      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "playwright-core": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/playwright/node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/reader/package-lock.json
+++ b/reader/package-lock.json
@@ -21,6 +21,9 @@
         "react-dom": "^19.2.4",
         "tailwindcss": "^4.2.2"
       },
+      "devDependencies": {
+        "@playwright/test": "^1.59.1"
+      },
       "engines": {
         "node": ">=22.12.0"
       }
@@ -2717,6 +2720,22 @@
       "resolved": "https://registry.npmjs.org/@oslojs/encoding/-/encoding-1.1.0.tgz",
       "integrity": "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==",
       "license": "MIT"
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-rc.3",
@@ -7880,6 +7899,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/reader/src/components/CodexRenderer.astro
+++ b/reader/src/components/CodexRenderer.astro
@@ -3,6 +3,7 @@ import Heading from './blocks/Heading.astro';
 import Paragraph from './blocks/Paragraph.astro';
 import BookImage from './blocks/BookImage.astro';
 import Widget from './blocks/Widget.tsx';
+import YouTubeEmbed from './widgets/YouTubeEmbed.tsx';
 import type { CodexBlock } from '../types/codex';
 
 interface Props {
@@ -45,10 +46,23 @@ const { blocks } = Astro.props;
           />
         );
       case 'widget':
+        const widgetType = (block.properties?.widget_type as string) || 'default';
+
+        if (widgetType === 'youtube') {
+          return (
+            <YouTubeEmbed
+              client:visible
+              videoId={(block.properties?.video_id as string) || ''}
+              title={(block.properties?.title as string) || block.content}
+              style={block.style}
+            />
+          );
+        }
+
         return (
           <Widget
             client:load
-            type={(block.properties?.widget_type as string) || 'default'}
+            type={widgetType}
             properties={block.properties}
             style={block.style}
           />

--- a/reader/src/components/CodexRenderer.astro
+++ b/reader/src/components/CodexRenderer.astro
@@ -49,10 +49,13 @@ const { blocks } = Astro.props;
         const widgetType = (block.properties?.widget_type as string) || 'default';
 
         if (widgetType === 'youtube') {
+          const videoId = block.properties?.video_id as string | undefined;
+          if (!videoId) return null;
+
           return (
             <YouTubeEmbed
               client:visible
-              videoId={(block.properties?.video_id as string) || ''}
+              videoId={videoId}
               title={(block.properties?.title as string) || block.content}
               style={block.style}
             />

--- a/reader/src/components/widgets/YouTubeEmbed.tsx
+++ b/reader/src/components/widgets/YouTubeEmbed.tsx
@@ -1,0 +1,69 @@
+import React, { useState } from 'react';
+import { Play } from 'lucide-react';
+import { snakeToCamel } from '../../utils/styleUtils';
+import type { CodexStyle } from '../../types/codex';
+
+interface YouTubeEmbedProps {
+  videoId: string;
+  title?: string;
+  style?: CodexStyle;
+}
+
+const YouTubeEmbed: React.FC<YouTubeEmbedProps> = ({ videoId, title = 'YouTube Video', style }) => {
+  const [isLoaded, setIsLoaded] = useState(false);
+  const camelStyle = snakeToCamel(style);
+
+  const thumbnailUrl = `https://i.ytimg.com/vi/${videoId}/hqdefault.jpg`;
+  const embedUrl = `https://www.youtube.com/embed/${videoId}?autoplay=1`;
+
+  if (isLoaded) {
+    return (
+      <div
+        className="relative w-full aspect-video rounded-xl overflow-hidden shadow-lg my-8"
+        style={camelStyle}
+      >
+        <iframe
+          src={embedUrl}
+          title={title}
+          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+          allowFullScreen
+          className="absolute inset-0 w-full h-full border-0"
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="relative w-full aspect-video rounded-xl overflow-hidden shadow-lg my-8 group cursor-pointer bg-gray-100"
+      style={camelStyle}
+      onClick={() => setIsLoaded(true)}
+      role="button"
+      aria-label={`Play video: ${title}`}
+      tabIndex={0}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          setIsLoaded(true);
+        }
+      }}
+    >
+      <img
+        src={thumbnailUrl}
+        alt={title}
+        className="absolute inset-0 w-full h-full object-cover transition-transform duration-300 group-hover:scale-105"
+        loading="lazy"
+      />
+      <div className="absolute inset-0 flex items-center justify-center bg-black/10 group-hover:bg-black/20 transition-colors duration-300">
+        <div className="w-16 h-16 md:w-20 md:h-20 bg-red-600 rounded-full flex items-center justify-center shadow-2xl transition-transform duration-300 group-hover:scale-110">
+          <Play className="w-8 h-8 md:w-10 md:h-10 text-white fill-current ml-1" />
+        </div>
+      </div>
+      <div className="absolute bottom-0 left-0 right-0 p-4 bg-gradient-to-t from-black/60 to-transparent">
+        <span className="text-white font-medium truncate block">{title}</span>
+      </div>
+    </div>
+  );
+};
+
+export default YouTubeEmbed;

--- a/reader/src/components/widgets/YouTubeEmbed.tsx
+++ b/reader/src/components/widgets/YouTubeEmbed.tsx
@@ -9,12 +9,12 @@ interface YouTubeEmbedProps {
   style?: CodexStyle;
 }
 
-const YouTubeEmbed: React.FC<YouTubeEmbedProps> = ({ videoId, title = 'YouTube Video', style }) => {
+const YouTubeEmbed = ({ videoId, title = 'YouTube Video', style }: YouTubeEmbedProps) => {
   const [isLoaded, setIsLoaded] = useState(false);
   const camelStyle = snakeToCamel(style);
 
   const thumbnailUrl = `https://i.ytimg.com/vi/${videoId}/hqdefault.jpg`;
-  const embedUrl = `https://www.youtube.com/embed/${videoId}?autoplay=1`;
+  const embedUrl = `https://www.youtube.com/embed/${videoId}?autoplay=1&rel=0`;
 
   if (isLoaded) {
     return (
@@ -51,6 +51,9 @@ const YouTubeEmbed: React.FC<YouTubeEmbedProps> = ({ videoId, title = 'YouTube V
       <img
         src={thumbnailUrl}
         alt={title}
+        onError={(e) => {
+          (e.target as HTMLImageElement).src = `https://i.ytimg.com/vi/${videoId}/mqdefault.jpg`;
+        }}
         className="absolute inset-0 w-full h-full object-cover transition-transform duration-300 group-hover:scale-105"
         loading="lazy"
       />

--- a/reader/src/fixtures/mock_manifest.json
+++ b/reader/src/fixtures/mock_manifest.json
@@ -63,6 +63,20 @@
         "margin_top": 10
       },
       "bbox": { "x0": 0, "y0": 100, "x1": 100, "y1": 120 }
+    },
+    {
+      "id": "550e8400-e29b-41d4-a716-446655440005",
+      "type": "widget",
+      "properties": {
+        "widget_type": "youtube",
+        "video_id": "dQw4w9WgXcQ",
+        "title": "Never Gonna Give You Up"
+      },
+      "style": {
+        "margin_top": 20,
+        "margin_bottom": 20
+      },
+      "bbox": { "x0": 0, "y0": 125, "x1": 100, "y1": 150 }
     }
   ],
   "assets": {}


### PR DESCRIPTION
This PR implements a new YouTube widget for the reader frontend. 

The widget follows the "facade" pattern to optimize performance:
1. Initially, only a high-quality thumbnail and a custom play button are rendered.
2. The heavy YouTube iframe is only loaded when the user clicks on the widget.
3. It supports accessibility via keyboard navigation (Enter/Space to play).
4. It's integrated into the `CodexRenderer` using Astro's `client:visible` directive to further defer JS execution until it's in view.

Verified visually and with Playwright.

Fixes #28

---
*PR created automatically by Jules for task [6232435501893643506](https://jules.google.com/task/6232435501893643506) started by @anderson-timana*