### PR TITLE
Reader: Implement Manifest Loader and Fix Typing

### DIFF
--- a/reader/src/components/blocks/BookImage.astro
+++ b/reader/src/components/blocks/BookImage.astro
@@ -35,19 +35,27 @@ if (style?.text_align === 'left') {
   alignmentClass = "ml-auto mr-0";
 }
 
-// Handle image source typing for Astro's Image component
-// If src is a string, it must be an external URL or a public path.
-// If it's ImageMetadata, it's a statically imported local image.
-const imageSrc = src as any;
+const commonClass = `rounded-lg shadow-sm block ${alignmentClass} bg-gray-100 dark:bg-gray-800 w-full h-auto`;
 ---
 
 <div class="w-full overflow-hidden" style={containerStyle}>
-  <Image
-    src={imageSrc}
-    alt={alt}
-    width={width || 1200}
-    height={height || 800}
-    class={`rounded-lg shadow-sm block ${alignmentClass} bg-gray-100 dark:bg-gray-800 w-full h-auto`}
-    style={imageStyle}
-  />
+  {typeof src === 'string' ? (
+    <img
+      src={src}
+      alt={alt}
+      width={width || 1200}
+      height={height || 800}
+      class={commonClass}
+      style={imageStyle}
+    />
+  ) : (
+    <Image
+      src={src}
+      alt={alt}
+      width={width || 1200}
+      height={height || 800}
+      class={commonClass}
+      style={imageStyle}
+    />
+  )}
 </div>

--- a/reader/src/components/blocks/BookImage.astro
+++ b/reader/src/components/blocks/BookImage.astro
@@ -1,5 +1,7 @@
 ---
 import { Image } from 'astro:assets';
+import type { ImageMetadata } from 'astro';
+import type { CodexStyle } from '../../types/codex';
 
 interface Props {
   src: string | ImageMetadata;
@@ -7,11 +9,7 @@ interface Props {
   aspectRatio?: number | string;
   width?: number;
   height?: number;
-  style?: {
-    margin_top?: number;
-    margin_bottom?: number;
-    text_align?: 'left' | 'center' | 'right';
-  };
+  style?: CodexStyle;
 }
 
 const { src, alt, aspectRatio, width, height, style } = Astro.props;
@@ -36,11 +34,16 @@ if (style?.text_align === 'left') {
 } else if (style?.text_align === 'right') {
   alignmentClass = "ml-auto mr-0";
 }
+
+// Handle image source typing for Astro's Image component
+// If src is a string, it must be an external URL or a public path.
+// If it's ImageMetadata, it's a statically imported local image.
+const imageSrc = src as any;
 ---
 
 <div class="w-full overflow-hidden" style={containerStyle}>
   <Image
-    src={src}
+    src={imageSrc}
     alt={alt}
     width={width || 1200}
     height={height || 800}

--- a/reader/src/components/blocks/Heading.astro
+++ b/reader/src/components/blocks/Heading.astro
@@ -1,19 +1,10 @@
 ---
+import type { CodexStyle } from '../../types/codex';
+
 interface Props {
   level: 1 | 2 | 3 | 4 | 5 | 6 | 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
   content: string;
-  style?: {
-    font_size?: number;
-    font_weight?: string;
-    line_height?: number;
-    color?: string;
-    text_align?: string;
-    margin_top?: number;
-    margin_bottom?: number;
-    font_family?: string;
-    text_decoration?: string;
-    font_style?: string;
-  };
+  style?: CodexStyle;
 }
 
 const { level, content, style } = Astro.props;

--- a/reader/src/components/blocks/Paragraph.astro
+++ b/reader/src/components/blocks/Paragraph.astro
@@ -1,18 +1,9 @@
 ---
+import type { CodexStyle } from '../../types/codex';
+
 interface Props {
   content: string;
-  style?: {
-    font_size?: number;
-    font_weight?: string;
-    line_height?: number;
-    color?: string;
-    text_align?: string;
-    margin_top?: number;
-    margin_bottom?: number;
-    font_family?: string;
-    text_decoration?: string;
-    font_style?: string;
-  };
+  style?: CodexStyle;
 }
 
 const { content, style } = Astro.props;

--- a/reader/src/pages/index.astro
+++ b/reader/src/pages/index.astro
@@ -5,8 +5,13 @@ import { Sidebar } from '../components/Sidebar';
 import { NavigationControls } from '../components/NavigationControls';
 import CodexRenderer from '../components/CodexRenderer.astro';
 import mockManifest from '../fixtures/mock_manifest.json';
+import { loadManifest } from '../utils/manifestLoader';
 
-const { meta, blocks } = mockManifest;
+// Load the manifest using the loader utility.
+// In a real production scenario, the source could be an external URL
+// from Astro.props, an environment variable, or a dynamic API endpoint.
+const manifest = await loadManifest(mockManifest);
+const { meta, blocks } = manifest;
 
 // SEO Metadata Extraction with Fallbacks
 const seoTitle = meta.seo?.title || meta.title;
@@ -37,7 +42,7 @@ const mockChapters = [
 
 	<main class="max-w-3xl mx-auto py-12 px-6">
 		<section class="space-y-6">
-			<CodexRenderer blocks={blocks as any} />
+			<CodexRenderer blocks={blocks} />
 		</section>
 	</main>
 </Layout>

--- a/reader/src/pages/index.astro
+++ b/reader/src/pages/index.astro
@@ -8,9 +8,10 @@ import mockManifest from '../fixtures/mock_manifest.json';
 import { loadManifest } from '../utils/manifestLoader';
 
 // Load the manifest using the loader utility.
-// In a real production scenario, the source could be an external URL
-// from Astro.props, an environment variable, or a dynamic API endpoint.
-const manifest = await loadManifest(mockManifest);
+// It prioritizes a public environment variable if provided,
+// falling back to the local mock manifest in development.
+const manifestUrl = import.meta.env.PUBLIC_MANIFEST_URL;
+const manifest = await loadManifest(manifestUrl || mockManifest);
 const { meta, blocks } = manifest;
 
 // SEO Metadata Extraction with Fallbacks

--- a/reader/src/types/codex.ts
+++ b/reader/src/types/codex.ts
@@ -1,3 +1,5 @@
+import type { ImageMetadata } from 'astro';
+
 export interface CodexStyle {
   font_size?: number;
   font_weight?: string;
@@ -16,7 +18,7 @@ export type CodexBlockType = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'p' | 'im
 export interface CodexBlock {
   type: CodexBlockType;
   content?: string;
-  src?: string;
+  src?: string | ImageMetadata;
   alt?: string;
   level?: 1 | 2 | 3 | 4 | 5 | 6;
   style?: CodexStyle;

--- a/reader/src/types/codex.ts
+++ b/reader/src/types/codex.ts
@@ -34,7 +34,7 @@ export interface CodexSEO {
 
 export interface CodexMeta {
   title: string;
-  description: string;
+  description?: string;
   author?: string;
   date?: string;
   seo?: CodexSEO;

--- a/reader/src/utils/manifestLoader.ts
+++ b/reader/src/utils/manifestLoader.ts
@@ -1,0 +1,64 @@
+import type { CodexManifest, CodexBlockType } from '../types/codex';
+
+const VALID_BLOCK_TYPES: CodexBlockType[] = ['h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'p', 'image', 'widget'];
+
+/**
+ * Validates a manifest object at runtime.
+ * Throws an error if the manifest is invalid.
+ */
+export function validateManifest(data: any): asserts data is CodexManifest {
+  if (!data || typeof data !== 'object') {
+    throw new Error('Manifest must be an object');
+  }
+
+  if (typeof data.version !== 'string') {
+    throw new Error('Manifest must have a string version');
+  }
+
+  if (!data.meta || typeof data.meta !== 'object') {
+    throw new Error('Manifest must have a meta object');
+  }
+
+  if (typeof data.meta.title !== 'string') {
+    throw new Error('Manifest meta must have a string title');
+  }
+
+  if (typeof data.meta.description !== 'string') {
+    throw new Error('Manifest meta must have a string description');
+  }
+
+  if (!Array.isArray(data.blocks)) {
+    throw new Error('Manifest blocks must be an array');
+  }
+
+  for (let i = 0; i < data.blocks.length; i++) {
+    const block = data.blocks[i];
+    if (!block || typeof block !== 'object') {
+      throw new Error(`Block at index ${i} must be an object`);
+    }
+    if (!VALID_BLOCK_TYPES.includes(block.type)) {
+      throw new Error(`Invalid block type at index ${i}: ${block.type}`);
+    }
+  }
+}
+
+/**
+ * Loads a Codex manifest from a string URL, URL object, or an existing object.
+ * Returns a fully-typed CodexManifest.
+ */
+export async function loadManifest(source: string | URL | object): Promise<CodexManifest> {
+  let data: any;
+
+  if (typeof source === 'string' || source instanceof URL) {
+    const response = await fetch(source);
+    if (!response.ok) {
+      throw new Error(`Failed to load manifest from ${source.toString()}: ${response.statusText}`);
+    }
+    data = await response.json();
+  } else {
+    data = source;
+  }
+
+  validateManifest(data);
+  return data as CodexManifest;
+}

--- a/reader/src/utils/manifestLoader.ts
+++ b/reader/src/utils/manifestLoader.ts
@@ -23,8 +23,8 @@ export function validateManifest(data: any): asserts data is CodexManifest {
     throw new Error('Manifest meta must have a string title');
   }
 
-  if (typeof data.meta.description !== 'string') {
-    throw new Error('Manifest meta must have a string description');
+  if (data.meta.description !== undefined && typeof data.meta.description !== 'string') {
+    throw new Error('Manifest meta description must be a string if provided');
   }
 
   if (!Array.isArray(data.blocks)) {


### PR DESCRIPTION
This PR implements a robust manifest loading utility for the Project Codex Reader. It adds runtime validation to ensure that any manifest loaded (whether from a static import or a future external fetch) conforms to the expected `CodexManifest` structure. 

Key changes:
1. **Manifest Loader:** A new utility in `reader/src/utils/manifestLoader.ts` that uses TypeScript type assertions to validate manifest data at runtime.
2. **Type Safety:** Improved the `CodexBlock` and `CodexStyle` interfaces in `reader/src/types/codex.ts`. Specifically, `src` now correctly accepts `ImageMetadata` to support Astro's optimized images without casting.
3. **Component Refactoring:** Cleaned up `CodexRenderer.astro` and individual block components to remove unsafe `as any` casts, ensuring that props are passed with correct types.
4. **Integration:** Updated `index.astro` to use the new loader, providing a pattern for future dynamic manifest loading while keeping the current mock data working.

Note: During verification, some dependency issues were noted in the environment's `package.json` (hallucinated versions for TypeScript and React). While I attempted to revert these to restore build stability, some peer dependency conflicts remain in the local environment that may require a clean `node_modules` state.

Fixes #51

---
*PR created automatically by Jules for task [197784396095197676](https://jules.google.com/task/197784396095197676) started by @anderson-timana*