### PR TITLE
Create Build Script (Astro)

### DIFF
--- a/reader/package-lock.json
+++ b/reader/package-lock.json
@@ -9086,13 +9086,13 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"

--- a/scripts/build_export.js
+++ b/scripts/build_export.js
@@ -42,7 +42,7 @@ function run() {
     console.log(`Artifacts available in: ${distDir}`);
   } catch (error) {
     console.error('--- Build Export Failed ---');
-    console.error(error.message);
+    console.error(error);
     process.exit(1);
   }
 }

--- a/scripts/build_export.js
+++ b/scripts/build_export.js
@@ -1,0 +1,50 @@
+import { execSync } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+/**
+ * Project Codex: Build Export Script
+ * This script automates the Astro build process and validates the output.
+ */
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+function run() {
+  const readerDir = path.join(__dirname, '..', 'reader');
+  const distDir = path.join(readerDir, 'dist');
+
+  console.log('--- Starting Build Export Process ---');
+
+  try {
+    // 1. Run npm install
+    console.log('Executing: npm install in reader/ directory...');
+    // Using --legacy-peer-deps due to Astro 6 vs @vite-pwa/astro conflict
+    execSync('npm install --legacy-peer-deps', { cwd: readerDir, stdio: 'inherit' });
+
+    // 2. Run npm run build (Astro)
+    console.log('Executing: npm run build...');
+    execSync('npm run build', { cwd: readerDir, stdio: 'inherit' });
+
+    // 3. Validate dist/ directory existence and key files
+    console.log('Validating build artifacts...');
+    if (!fs.existsSync(distDir)) {
+      throw new Error(`Validation Failed: dist/ directory not found at ${distDir}`);
+    }
+
+    const indexFile = path.join(distDir, 'index.html');
+    if (!fs.existsSync(indexFile)) {
+      throw new Error(`Validation Failed: index.html not found at ${indexFile}`);
+    }
+
+    console.log('--- Build Export Successful ---');
+    console.log(`Artifacts available in: ${distDir}`);
+  } catch (error) {
+    console.error('--- Build Export Failed ---');
+    console.error(error.message);
+    process.exit(1);
+  }
+}
+
+run();


### PR DESCRIPTION
I have created the requested build export script for the Astro reader project. 

Key features:
1.  **Automated Build Pipeline**: The `scripts/build_export.js` script handles the end-to-end build process for the `reader` directory.
2.  **Dependency Handling**: It uses `--legacy-peer-deps` to resolve a conflict between Astro 6 and the PWA integration, ensuring the build can run in the current environment.
3.  **Validation Logic**: It automatically verifies that the `dist/` directory exists and contains the critical `index.html` file after a successful build.
4.  **Modern Standards**: The script is implemented using Node.js ESM (ECMAScript Modules) to align with the rest of the reader project's configuration.

I verified the script by running it successfully and checking that all expected artifacts were generated in `reader/dist/`. I also ran `npx astro check` to ensure no regressions were introduced.

Fixes #29

---
*PR created automatically by Jules for task [4488741017795142346](https://jules.google.com/task/4488741017795142346) started by @anderson-timana*